### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,10 @@
 
 name: Node.js Package
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/alexandrainst/node-red-contrib-ui-upload/security/code-scanning/2](https://github.com/alexandrainst/node-red-contrib-ui-upload/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required. Based on the workflow's actions, the following permissions are needed:
- `contents: read` for accessing the repository's contents during the build and test steps.
- `packages: write` for publishing the package to npm.

This ensures that the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
