### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +21,9 @@ jobs:
       - run: npm test
 
   publish-npm:
+    permissions:
+      contents: read
+      packages: write
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/alexandrainst/node-red-contrib-ui-upload/security/code-scanning/3](https://github.com/alexandrainst/node-red-contrib-ui-upload/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimum required permissions for the `GITHUB_TOKEN`. Based on the workflow's operations, the `contents: read` permission is sufficient for the `build` job, while the `publish-npm` job requires `contents: read` and possibly `packages: write` to publish the package to npm. The commented-out `publish-gpr` job would also require similar permissions if it were to be used.

The `permissions` block can be added at the workflow level to apply to all jobs or at the job level for more granular control. In this case, we will add job-specific permissions to ensure each job has only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
